### PR TITLE
network manager typo fix

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -79,7 +79,7 @@ bin_exists cmake || die "Cmake not installed."
 bin_exists blueman-manager || warn "Blueman not installed." # warn here because not everyone use bluetooth
 bin_exists pipewire || die "Pipewire not installed."
 bin_exists wl-copy || die "Wl-clipboard not installed."
-(bin_exists NetworkManagder || bin_exists diw) || die "Need a network manager: NetworkManager or iw (recommended is NetworkManager, for bar's extra vpn module)"
+(bin_exists NetworkManager || bin_exists diw) || die "Need a network manager: NetworkManager or iw (recommended is NetworkManager, for bar's extra vpn module)"
 bin_exists nmcli || warn "nmcli not installed. if you will use vpn module in bar, nmcli is needed."
 
 REAL_HOME=$(getent passwd "${SUDO_USER:-$USER}" | cut -d: -f6)


### PR DESCRIPTION
The NetworkManager check had a typo, which was causing the installation to fail even though NetworkManager was installed.

I investigated the issue and found that `NetworkManager` was misspelled as `NetworkManagder` in the dependency check. Fixing the spelling resolved the issue.

It now works as expected. I also verified the fix on my local machine.
