### PR TITLE
fix(network): correct Wi-Fi signal scaling and icon tier calculation

### DIFF
--- a/qml/Network.qml
+++ b/qml/Network.qml
@@ -18,7 +18,7 @@ RowLayout {
   property var tetherDevice: Networking.devices.values.find(d => d.type === DeviceType.Wired && d.connected)
   readonly property bool tethered: tetherDevice !== undefined
 
-  readonly property real signal: active ? active.signalStrength : 0
+  readonly property real signal: active ? active.signalStrength * 100 : 0
 
   readonly property string icon: {
     if (root.tethered) return String.fromCodePoint(0xf287) // nf-fa-usb
@@ -29,7 +29,7 @@ RowLayout {
              : s >= 0.50 ? 3
              : s >= 0.25 ? 2
              : 1
-    return String.fromCodePoint(0xf091f + (tier + 1) * 3)
+    return String.fromCodePoint(0xf091f + (tier - 1) * 3)
   }
 
   Text {


### PR DESCRIPTION
# fix(network): correct Wi-Fi signal scaling and icon codepoint calculation

## Summary

This PR addresses two related bugs in the Wi-Fi status module (`qml/Network.qml`):

1. **Wi-Fi tooltip always displayed `1% signal` (or `0%`)** regardless of actual connection quality.
2. **Wi-Fi icon showed a disabled/slashed Wi-Fi glyph (`md-wifi_strength_off_outline`)** when connected with high signal strength.

---

## Issue 1: Wi-Fi Signal Strength Scaling

### Problem

When hovering over the network indicator in the status bar, the tooltip consistently showed `1% signal` (e.g. `Anna-5G • 1% signal`) even with a strong Wi-Fi connection.

### Root Cause

`Quickshell.Networking` exposes `WifiNetwork.signalStrength` as a normalized floating-point number in the range `[0.0, 1.0]` (e.g., `0.85` for 85% signal).

In `qml/Network.qml`:

```qml
readonly property real signal: active ? active.signalStrength : 0
```

Because this was not converted to a percentage (0–100), `m.signal` was passed as `0.85` to `qml/TooltipPopup.qml`:

```qml
return m.active.name + " • " + Math.round(m.signal) + "% signal"
```

`Math.round(0.85)` rounded down to `1`, resulting in `"1% signal"`.

### Solution

Multiply `active.signalStrength` by `100` in `qml/Network.qml` so `signal` represents a standard `0–100` percentage value:

```qml
readonly property real signal: active ? active.signalStrength * 100 : 0
```

---

## Issue 2: Wi-Fi Tier Icon Codepoint Offset

### Problem

When connected to a network with strong signal (Tier 4 / $\ge 75\%$), the status bar displayed a disabled/slashed Wi-Fi icon instead of the full signal strength icon.

### Root Cause

In Nerd Fonts (Material Design Icons set), the Wi-Fi strength glyphs are stepped by `+3` starting at base codepoint `0xf091f`:

| Codepoint | Glyph Name                     | Description             |
| :-------- | :----------------------------- | :---------------------- |
| `0xf091f` | `md-wifi_strength_1`           | 1 bar (low signal)      |
| `0xf0922` | `md-wifi_strength_2`           | 2 bars                  |
| `0xf0925` | `md-wifi_strength_3`           | 3 bars                  |
| `0xf0928` | `md-wifi_strength_4`           | 4 bars (full signal)    |
| `0xf092d` | `md-wifi_strength_off`         | Wi-Fi disabled          |
| `0xf092e` | `md-wifi_strength_off_outline` | **Wi-Fi off / slashed** |

The existing formula in `qml/Network.qml` was:

```qml
let tier = s >= 0.75 ? 4
         : s >= 0.50 ? 3
         : s >= 0.25 ? 2
         : 1

return String.fromCodePoint(0xf091f + (tier + 1) * 3) // ❌ Off-by-one
```

Because `0xf091f` is already Tier 1, adding `(tier + 1) * 3` caused an off-by-one overshoot:

- **Tier 4**: `0xf091f + (4 + 1) * 3 = 0xf091f + 15 = 0xf092e` (`md-wifi_strength_off_outline` 🚫)
- **Tier 3**: `0xf091f + (3 + 1) * 3 = 0xf091f + 12 = 0xf092b` (`md-wifi_strength_alert_outline` ⚠️)
- **Tier 2**: `0xf091f + (2 + 1) * 3 = 0xf091f + 9 = 0xf0928` (`md-wifi_strength_4`)
- **Tier 1**: `0xf091f + (1 + 1) * 3 = 0xf091f + 6 = 0xf0925` (`md-wifi_strength_3`)

_(Note: When Issue 1 was present, `tier` was always stuck at `1` due to double division, which masked this bug by displaying Tier 3 icons)._

### Solution

Update the formula to use `(tier - 1) * 3`:

```qml
return String.fromCodePoint(0xf091f + (tier - 1) * 3)
```

Mapping with the fix:

- **Tier 1**: `0xf091f + 0 = 0xf091f` (`md-wifi_strength_1`)
- **Tier 2**: `0xf091f + 3 = 0xf0922` (`md-wifi_strength_2`)
- **Tier 3**: `0xf091f + 6 = 0xf0925` (`md-wifi_strength_3`)
- **Tier 4**: `0xf091f + 9 = 0xf0928` (`md-wifi_strength_4`)

---

## Changes

```diff
--- a/qml/Network.qml
+++ b/qml/Network.qml
@@ -18,7 +18,7 @@ RowLayout {
   property var tetherDevice: Networking.devices.values.find(d => d.type === DeviceType.Wired && d.connected)
   readonly property bool tethered: tetherDevice !== undefined

-  readonly property real signal: active ? active.signalStrength : 0
+  readonly property real signal: active ? active.signalStrength * 100 : 0

   readonly property string icon: {
     if (root.tethered) return String.fromCodePoint(0xf287) // nf-fa-usb
@@ -29,7 +29,7 @@ RowLayout {
              : s >= 0.50 ? 3
              : s >= 0.25 ? 2
              : 1
-    return String.fromCodePoint(0xf091f + (tier + 1) * 3)
+    return String.fromCodePoint(0xf091f + (tier - 1) * 3)
   }

   Text {
```

---

## Verification

- [x] Connected to Wi-Fi access point and hovered over pill bar network module: tooltip accurately shows current signal percentage (e.g. `85% signal`).
- [x] Verified status bar icon correctly reflects signal levels (Tier 1 through Tier 4) instead of showing the slashed/disabled icon on strong signals.
- [x] Verified disconnected / Wi-Fi off states still render `md-wifi_strength_off` (`0xf092d`).
