### PR TITLE
fix: prevent command substitution in holidays prompt

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,7 +43,7 @@ if [[ "$1" != "--skip-deps" ]]; then
       PY=/usr/bin/python3
 
       if ! sudo -u "$SUDO_USER" "$PY" -m pip show holidays >/dev/null 2>/dev/null; then
-         read -p "Do you want event dates in calendar popup? It just needs a python lib `holidays` to run [y/N]: " ask
+         read -p "Do you want event dates in calendar popup? It just needs a python lib 'holidays' to run [y/N]: " ask
 
          if [[ "$ask" == "y" || "$ask" == "Y" ]]; then
             if ! sudo -u "$SUDO_USER" "$PY" -m pip --version >/dev/null 2>/dev/null; then


### PR DESCRIPTION
In the install script the backticks in the holidays -> ``` `holidays` ``` was causing a command substitution resulting in the message: 

```
./install.sh: line 46: holidays: command not found
Do you want event dates in calendar popup? It just needs a python lib  to run [y/N]: 
```
as a result, the package name was omitted from the prompt, making the sentence appear incomplete.

changing it to: 
``` 'holidays' ``` does not do the same anymore and displays the message properly as:

```
Do you want event dates in calendar popup? It just needs a python lib 'holidays' to run [y/N]:
```


before:
<img width="957" height="180" alt="2026-09-03-164614_hyprshot" src="https://github.com/user-attachments/assets/814c2d7c-d65c-4c6c-811f-6b9d27be0309" />


after:
<img width="1055" height="267" alt="2026-09-03-164553_hyprshot" src="https://github.com/user-attachments/assets/9a14d15f-5390-457d-bb70-42b62845120f" />
